### PR TITLE
Improve handling of missing videos

### DIFF
--- a/Classes/Service/YoutubeService.php
+++ b/Classes/Service/YoutubeService.php
@@ -80,8 +80,8 @@ class YoutubeService
                 $duration = $data->duration ?? null;
             } else {
                 $youtubeImageArray = $this->getBestPossibleYoutubeImage($videoID);
-                $image = $youtubeImageArray['image'];
-                $resolution = $youtubeImageArray['resolution'];
+                $image = $youtubeImageArray['image'] ?? null;
+                $resolution = $youtubeImageArray['resolution'] ?? null;
             }
 
             if (isset($image)) {


### PR DESCRIPTION
As the return value of `getBestPossibleYoutubeImage` can be null, it throws warnings because of missing array keys, if the video doesn't exist or is private.