### PR TITLE
BUGFIX: Wrap createDataFromService method, because the parameter do not match the connected signal parameter

### DIFF
--- a/Classes/Package.php
+++ b/Classes/Package.php
@@ -19,7 +19,7 @@ class Package extends BasePackage
     public function boot(Bootstrap $bootstrap): void
     {
         $dispatcher = $bootstrap->getSignalSlotDispatcher();
-        $dispatcher->connect(Node::class, 'nodeAdded', MetadataService::class, 'createDataFromService');
+        $dispatcher->connect(Node::class, 'nodeAdded', MetadataService::class, 'onNodeAdded');
         $dispatcher->connect(Node::class, 'nodePropertyChanged', MetadataService::class, 'updateDataFromService');
         $dispatcher->connect(
             Workspace::class,

--- a/Classes/Service/MetadataService.php
+++ b/Classes/Service/MetadataService.php
@@ -53,6 +53,19 @@ class MetadataService
     protected $defaultReturn = ['node' => null];
 
     /**
+     * Wrapper method to handle signals from Node::nodeAdded
+     *
+     * @param NodeInterface $node
+     * @return array|null[]
+     * @throws IllegalObjectTypeException
+     * @throws NodeException
+     */
+    public function onNodeAdded(NodeInterface $node)
+    {
+        return $this->createDataFromService($node);
+    }
+
+    /**
      * Create data
      *
      * @param NodeInterface $node


### PR DESCRIPTION
Fixes #28 

The signal for newly added nodes (Node::emitNodeAdded) has one parameter (`NodeInterface $node`).
https://github.com/neos/content-repository/blob/8.3/Classes/Domain/Model/Node.php#L758

The connected slot method MetadataService::createDataFromService excepts two parameter (`NodeInterface $node, bool $remove = false`). 
https://github.com/jonnitto/Jonnitto.PrettyEmbedHelper/blob/master/Classes/Service/MetadataService.php#L64

As the signalSlot dispatcher adds the name of the signal as last parameter to the call (https://github.com/neos/flow/blob/8.3/Classes/SignalSlot/Dispatcher.php#L183) of the slot, the `bool $remove` flag is always `true`, if this method is called by the signal. This leads to the bug, that copied nodes don't have any metadata loaded.


To prevent this I wrapped the method with a dedicated "slot method" an just pass the right parameter.